### PR TITLE
Add support for nesting classes

### DIFF
--- a/processors/src/main/kotlin/com/alecarnevale/diplomatico/visitor/HashingRoomDBVersionVisitor.kt
+++ b/processors/src/main/kotlin/com/alecarnevale/diplomatico/visitor/HashingRoomDBVersionVisitor.kt
@@ -55,9 +55,9 @@ internal class HashingRoomDBVersionVisitor(
     val hash =
       entitiesFilePath
         .map { hashingFile(it) }
-        // contact entities hashes with its nested class hashes
+        // concat entities' hashes with its nested class' hashes
         .plus(nestedClassesFilePath.map { hashingFile(it) })
-        // generate a single String from many ones
+        // generate a single String starting many ones
         .merge()
 
     val qualifiedName = classDeclaration.qualifiedName?.asString()
@@ -97,7 +97,7 @@ internal class HashingRoomDBVersionVisitor(
     }
   }
 
-  // extract path of other classes that is being references in this entity
+  // extract path of other classes that is being references in this entity (or class when call recursively)
   private fun KSClassDeclaration.resolveNestedEntitiesPath(): List<String> =
     declarations
       .toList()
@@ -106,10 +106,11 @@ internal class HashingRoomDBVersionVisitor(
         property.resolveFilePath()
       }.filterNotNull()
 
-  // return the file path of this declaration, if it's not a built-in type
+  // return the file path of this declaration, if it's not a primitive type
   private fun KSPropertyDeclaration.resolveFilePath(): List<String?> {
     val classDeclaration =
       type.resolve().declaration.qualifiedName?.let {
+        // when resolving a primitive type (Int, String...) null is returned
         resolver.getClassDeclarationByName(it)
       }
     // return this file path (if not null) + any other file path discovered with this as root

--- a/processors/src/test/kotlin/com/alecarnevale/diplomatico/CompileSourceFiles.kt
+++ b/processors/src/test/kotlin/com/alecarnevale/diplomatico/CompileSourceFiles.kt
@@ -1,0 +1,37 @@
+package com.alecarnevale.diplomatico
+
+import com.alecarnevale.diplomatico.providers.HashingRoomDBVersionProcessorProvider
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.kspSourcesDir
+import com.tschuchort.compiletesting.symbolProcessorProviders
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+
+@OptIn(ExperimentalCompilerApi::class)
+internal fun compileSourceFiles(vararg sourceFiles: SourceFile): KspCompilationResult {
+  val kotlinCompilation =
+    KotlinCompilation().apply {
+      sources = sourceFiles.toMutableList().apply { add(databaseAnnotation) }
+      symbolProcessorProviders = listOf(HashingRoomDBVersionProcessorProvider())
+      inheritClassPath = true
+    }
+  return KspCompilationResult(
+    sourcesDir = kotlinCompilation.kspSourcesDir,
+    result = kotlinCompilation.compile(),
+  )
+}
+
+// we mirror Room Database annotation just for testing purpose
+// otherwise it couldn't possible access its argument
+private val databaseAnnotation by lazy {
+  SourceFile.kotlin(
+    "Database.kt",
+    """
+    package androidx.room
+
+    annotation class Database(
+      val entities: Array<KClass<*>> = []
+    )
+    """.trimIndent(),
+  )
+}

--- a/processors/src/test/kotlin/com/alecarnevale/diplomatico/HashingRoomDBVersionProcessorProviderNestingClassesTest.kt
+++ b/processors/src/test/kotlin/com/alecarnevale/diplomatico/HashingRoomDBVersionProcessorProviderNestingClassesTest.kt
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-// Test suite for specific to cover nesting classes case
+// Test suite to cover only nesting classes cases
 @OptIn(ExperimentalCompilerApi::class)
 internal class HashingRoomDBVersionProcessorProviderNestingClassesTest {
   @Test

--- a/processors/src/test/kotlin/com/alecarnevale/diplomatico/HashingRoomDBVersionProcessorProviderNestingClassesTest.kt
+++ b/processors/src/test/kotlin/com/alecarnevale/diplomatico/HashingRoomDBVersionProcessorProviderNestingClassesTest.kt
@@ -92,4 +92,100 @@ internal class HashingRoomDBVersionProcessorProviderNestingClassesTest {
       """,
     )
   }
+
+  @Test
+  fun `GIVEN a class FooParent with a nested data class FooChild with a nested data class FooGrandChild and its FooDatabase, WHEN @HashingRoomDBVersion is applied to FooDatabase and a property of FooGrandChild changes, THEN hashing value in the report changes`() {
+    var fooGrandChild =
+      SourceFile.kotlin(
+        "FooGrandChild.kt",
+        """
+        package com.example
+
+        data class FooGrandChild(
+          val x: Int,
+        )
+        """.trimIndent(),
+      )
+
+    val fooChild =
+      SourceFile.kotlin(
+        "FooChild.kt",
+        """
+        package com.example
+
+        data class FooChild(
+          val x: FooGrandChild,
+        )
+        """.trimIndent(),
+      )
+
+    val fooParent =
+      SourceFile.kotlin(
+        "FooParent.kt",
+        """
+        package com.example
+
+        import androidx.room.Entity
+        
+        @Entity
+        data class FooParent(
+          val x: FooChild,
+        )
+        """.trimIndent(),
+      )
+
+    val fooDatabase =
+      SourceFile.kotlin(
+        "FooDatabase.kt",
+        """
+        package com.example
+
+        import androidx.room.Database
+        import com.alecarnevale.diplomatico.api.HashingRoomDBVersion
+        
+        @HashingRoomDBVersion
+        @Database(entities = [FooParent::class])
+        class FooDatabase
+        """.trimIndent(),
+      )
+
+    var result = compileSourceFiles(fooGrandChild, fooChild, fooParent, fooDatabase)
+
+    assertEquals(KotlinCompilation.ExitCode.OK, result.result.exitCode)
+
+    result.assertGeneratedResources("com/alecarnevale/diplomatico/results/report.csv")
+    result.assertGeneratedContent(
+      "com/alecarnevale/diplomatico/results/report.csv",
+      """
+      com.example.FooDatabase,OpPxRPOJUxXQenwzaahYoD5a/3i0vpMuhe+Vw+jdnSg=
+      
+      """,
+    )
+
+    fooGrandChild =
+      SourceFile.kotlin(
+        "FooGrandChild.kt",
+        """
+        package com.example
+
+        data class FooGrandChild(
+          val x: Int,
+          val y: String,
+        )
+        """.trimIndent(),
+      )
+
+    result = compileSourceFiles(fooGrandChild, fooChild, fooParent, fooDatabase)
+
+    assertEquals(KotlinCompilation.ExitCode.OK, result.result.exitCode)
+
+    result.assertGeneratedResources("com/alecarnevale/diplomatico/results/report.csv")
+    result.assertGeneratedContent(
+      "com/alecarnevale/diplomatico/results/report.csv",
+      """
+      com.example.FooDatabase,gaomIsPFM0dfF8S13Y0V7l0EY82qiULQvlG/nJqxgLY=
+      
+      """,
+    )
+  }
 }

--- a/processors/src/test/kotlin/com/alecarnevale/diplomatico/HashingRoomDBVersionProcessorProviderNestingClassesTest.kt
+++ b/processors/src/test/kotlin/com/alecarnevale/diplomatico/HashingRoomDBVersionProcessorProviderNestingClassesTest.kt
@@ -1,0 +1,95 @@
+package com.alecarnevale.diplomatico
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+// Test suite for specific to cover nesting classes case
+@OptIn(ExperimentalCompilerApi::class)
+internal class HashingRoomDBVersionProcessorProviderNestingClassesTest {
+  @Test
+  fun `GIVEN a class FooParent with a nested data class FooChild and its FooDatabase, WHEN @HashingRoomDBVersion is applied to FooDatabase and a property of FooChild changes, THEN hashing value in the report changes`() {
+    var fooChild =
+      SourceFile.kotlin(
+        "FooChild.kt",
+        """
+        package com.example
+
+        data class FooChild(
+          val x: Int,
+        )
+        """.trimIndent(),
+      )
+
+    val fooParent =
+      SourceFile.kotlin(
+        "FooParent.kt",
+        """
+        package com.example
+
+        import androidx.room.Entity
+        
+        @Entity
+        data class FooParent(
+          val x: FooChild,
+        )
+        """.trimIndent(),
+      )
+
+    val fooDatabase =
+      SourceFile.kotlin(
+        "FooDatabase.kt",
+        """
+        package com.example
+
+        import androidx.room.Database
+        import com.alecarnevale.diplomatico.api.HashingRoomDBVersion
+        
+        @HashingRoomDBVersion
+        @Database(entities = [FooParent::class])
+        class FooDatabase
+        """.trimIndent(),
+      )
+
+    var result = compileSourceFiles(fooChild, fooParent, fooDatabase)
+
+    assertEquals(KotlinCompilation.ExitCode.OK, result.result.exitCode)
+
+    result.assertGeneratedResources("com/alecarnevale/diplomatico/results/report.csv")
+    result.assertGeneratedContent(
+      "com/alecarnevale/diplomatico/results/report.csv",
+      """
+      com.example.FooDatabase,VXV8r9+A5Dah0CFH58mqUmgOPWN1GDrCeTNcglifBEs=
+      
+      """,
+    )
+
+    fooChild =
+      SourceFile.kotlin(
+        "FooChild.kt",
+        """
+        package com.example
+
+        data class FooChild(
+          val x: Int,
+          val y: String,
+        )
+        """.trimIndent(),
+      )
+
+    result = compileSourceFiles(fooChild, fooParent, fooDatabase)
+
+    assertEquals(KotlinCompilation.ExitCode.OK, result.result.exitCode)
+
+    result.assertGeneratedResources("com/alecarnevale/diplomatico/results/report.csv")
+    result.assertGeneratedContent(
+      "com/alecarnevale/diplomatico/results/report.csv",
+      """
+      com.example.FooDatabase,H5kWB5LSqBIklkIObUliZiz8xff0dU9ZG/ZZcIi05tU=
+      
+      """,
+    )
+  }
+}

--- a/processors/src/test/kotlin/com/alecarnevale/diplomatico/HashingRoomDBVersionProcessorProviderTest.kt
+++ b/processors/src/test/kotlin/com/alecarnevale/diplomatico/HashingRoomDBVersionProcessorProviderTest.kt
@@ -1,16 +1,13 @@
 package com.alecarnevale.diplomatico
 
-import com.alecarnevale.diplomatico.providers.HashingRoomDBVersionProcessorProvider
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
-import com.tschuchort.compiletesting.kspSourcesDir
-import com.tschuchort.compiletesting.symbolProcessorProviders
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalCompilerApi::class)
-class HashingRoomDBVersionProcessorProviderTest {
+internal class HashingRoomDBVersionProcessorProviderTest {
   @Test
   fun `GIVEN a class Foo without Database annotation WHEN @HashingRoomDBVersion is applied to Foo, THEN compilation error and no report is not generated`() {
     val foo =
@@ -293,32 +290,4 @@ class HashingRoomDBVersionProcessorProviderTest {
       """,
     )
   }
-
-  private fun compileSourceFiles(vararg sourceFiles: SourceFile): KspCompilationResult {
-    val kotlinCompilation =
-      KotlinCompilation().apply {
-        sources = sourceFiles.toMutableList().apply { add(databaseAnnotation) }
-        symbolProcessorProviders = listOf(HashingRoomDBVersionProcessorProvider())
-        inheritClassPath = true
-      }
-    return KspCompilationResult(
-      sourcesDir = kotlinCompilation.kspSourcesDir,
-      result = kotlinCompilation.compile(),
-    )
-  }
-}
-
-// we mirror Room Database annotation just for testing purpose
-// otherwise it couldn't possible access its argument
-private val databaseAnnotation by lazy {
-  SourceFile.kotlin(
-    "Database.kt",
-    """
-    package androidx.room
-
-    annotation class Database(
-      val entities: Array<KClass<*>> = []
-    )
-    """.trimIndent(),
-  )
 }

--- a/processors/src/test/kotlin/com/alecarnevale/diplomatico/HashingRoomDBVersionProcessorProviderTest.kt
+++ b/processors/src/test/kotlin/com/alecarnevale/diplomatico/HashingRoomDBVersionProcessorProviderTest.kt
@@ -219,6 +219,81 @@ class HashingRoomDBVersionProcessorProviderTest {
     )
   }
 
+  @Test
+  fun `GIVEN a class Foo with Database annotation and entities field WHEN @HashingRoomDBVersion is applied to Foo but Foo changes, THEN reports generated change`() {
+    var fooEntity =
+      SourceFile.kotlin(
+        "FooEntity.kt",
+        """
+        package com.example
+
+        import androidx.room.Entity
+        
+        @Entity
+        data class FooEntity(
+          val x: Int,
+        )
+        """.trimIndent(),
+      )
+
+    val fooDatabase =
+      SourceFile.kotlin(
+        "FooDatabase.kt",
+        """
+        package com.example
+
+        import androidx.room.Database
+        import com.alecarnevale.diplomatico.api.HashingRoomDBVersion
+        
+        @HashingRoomDBVersion
+        @Database(entities = [FooEntity::class])
+        class FooDatabase
+        """.trimIndent(),
+      )
+
+    var result = compileSourceFiles(fooEntity, fooDatabase)
+
+    assertEquals(KotlinCompilation.ExitCode.OK, result.result.exitCode)
+
+    result.assertGeneratedResources("com/alecarnevale/diplomatico/results/report.csv")
+    result.assertGeneratedContent(
+      "com/alecarnevale/diplomatico/results/report.csv",
+      """
+      com.example.FooDatabase,rH6hy7aLdVv1fxCZlPqtsqRZauGUsJTim0CxRMDo8vg=
+      
+      """,
+    )
+
+    fooEntity =
+      SourceFile.kotlin(
+        "FooEntity.kt",
+        """
+        package com.example
+
+        import androidx.room.Entity
+        
+        @Entity
+        data class FooEntity(
+          val x: Int,
+          val y: String,
+        )
+        """.trimIndent(),
+      )
+
+    result = compileSourceFiles(fooEntity, fooDatabase)
+
+    assertEquals(KotlinCompilation.ExitCode.OK, result.result.exitCode)
+
+    result.assertGeneratedResources("com/alecarnevale/diplomatico/results/report.csv")
+    result.assertGeneratedContent(
+      "com/alecarnevale/diplomatico/results/report.csv",
+      """
+      com.example.FooDatabase,NyNDpYWpN9vFEOcaDrAI7JLXXA6MgaIKN1TLQQ7m/ms=
+      
+      """,
+    )
+  }
+
   private fun compileSourceFiles(vararg sourceFiles: SourceFile): KspCompilationResult {
     val kotlinCompilation =
       KotlinCompilation().apply {


### PR DESCRIPTION
Now `HashingRoomDBVersionProcessor` checks also in any class nested inside the entity, recursively.