### PR TITLE
Red PR - nested classes

### DIFF
--- a/demo/app/src/main/java/com/alecarnevale/diplomatico/demo/cocktail/Distilled.kt
+++ b/demo/app/src/main/java/com/alecarnevale/diplomatico/demo/cocktail/Distilled.kt
@@ -5,4 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 internal data class Distilled(
   val name: String,
+  val volume: Float = 0f,
 )


### PR DESCRIPTION
This PR must always **fail**: it changed a nested class of an entity without properly updating the DB versions and accepting the new report.