### PR TITLE
Support Android build variants

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -22,5 +22,5 @@ jobs:
       - name: Run build processor task
         run: ./gradlew :processors:build
       - name: Run Android assemble task
-        run: ./gradlew :demo:app:assemble
+        run: ./gradlew :demo:app:assembleDemoDebug
 

--- a/demo/app/build.gradle.kts
+++ b/demo/app/build.gradle.kts
@@ -30,6 +30,18 @@ android {
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
+        debug {
+            isDebuggable = true
+        }
+    }
+    flavorDimensions += "version"
+    productFlavors {
+        create("demo") {
+            dimension = "version"
+        }
+        create("full") {
+            dimension = "version"
+        }
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ junit-jupiter = "5.11.2"
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+android-build-gradle-api = { group = "com.android.tools.build", name = "gradle-api", version.ref = "agp" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }

--- a/gradle/plugins/build.gradle.kts
+++ b/gradle/plugins/build.gradle.kts
@@ -1,5 +1,6 @@
 repositories {
     mavenCentral()
+    google()
 }
 
 plugins {
@@ -22,4 +23,8 @@ gradlePlugin {
             description = ""
         }
     }
+}
+
+dependencies {
+    implementation(libs.android.build.gradle.api)
 }


### PR DESCRIPTION
Now the plugin registers `checkRoomVersions<buildType>` and `updateRoomVersions<buildType>`, and so the right KSP generated directory is looked at.