### PR TITLE
Red PR - contributing classes with contributes property

### DIFF
--- a/demo/core-entities/src/main/kotlin/com/alecarnevale/diplomatico/demo/core/entities/Soda.kt
+++ b/demo/core-entities/src/main/kotlin/com/alecarnevale/diplomatico/demo/core/entities/Soda.kt
@@ -2,4 +2,5 @@ package com.alecarnevale.diplomatico.demo.core.entities
 
 data class Soda(
   val name: String,
+  val brand: String,
 )


### PR DESCRIPTION
This PR must always **fail**: it changed a class contributing to a database, through `HashingRoomDBVersion.contributes`, without properly updating the DB versions and accepting the new report.